### PR TITLE
Add add-support-for-human-readable-start-times

### DIFF
--- a/src/main/java/org/testng/reporters/EmailableReporter2.java
+++ b/src/main/java/org/testng/reporters/EmailableReporter2.java
@@ -344,7 +344,7 @@ public class EmailableReporter2 implements IReporter {
               .append("<td rowspan=\"")
               .append(resultsCount)
               .append("\">")
-              .append(start)
+              .append(getFormattedStartTime(start))
               .append("</td>")
               .append("<td rowspan=\"")
               .append(resultsCount)
@@ -387,6 +387,10 @@ public class EmailableReporter2 implements IReporter {
       scenarioCount = scenarioIndex - startingScenarioIndex;
     }
     return scenarioCount;
+  }
+
+  protected String getFormattedStartTime(long start) {
+    return String.valueOf(start);
   }
 
   /** Writes the details for all test scenarios. */


### PR DESCRIPTION
Added new protected method to provide the start time, which can be overwritten in sub classes.

Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
